### PR TITLE
Adding react as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "typescript": "^3.7.3"
   },
   "peerDependencies": {
-    "ink": "2.6.x"
+    "ink": "2.6.x",
+    "react": ">=16.8.0"
   }
 }


### PR DESCRIPTION
Yarn 2.0 complains that `ink-quicksearch-input` uses `react` but doesn't define a dependency on it. I've defined it as a `peerDependency` in the same way as other `ink` packages such as [`ink-box`](https://github.com/sindresorhus/ink-box/blob/master/package.json#L61).