### PR TITLE
Generate proper types declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ink-quicksearch-input",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Quicksearch Input Component for Ink 2",
   "main": "build/QuickSearchInput.js",
-  "types": "src/QuickSearchInput.tsx",
+  "types": "build/QuickSearchInput.d.ts",
   "author": {
     "name": "John O'Sullivan <john@eximchain.com>"
   },
@@ -15,7 +15,7 @@
     "start": "node build/examples/ExampleDirectory.js"
   },
   "files": [
-    "src/QuickSearchInput.tsx",
+    "build/QuickSearchInput.d.ts",
     "build/QuickSearchInput.js",
     "tsconfig.json"
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       "allowSyntheticDefaultImports": true,
       "esModuleInterop": true,
       "typeRoots": ["node_modules/@types"],
-      "jsx": "react"
+      "jsx": "react",
+      "declaration": true
     },
     "typedocOptions": {
       "mode" : "modules",


### PR DESCRIPTION
Current modules causes errors when attempting to build in typescript project:
```
> tsc

node_modules/ink-quicksearch-input/src/QuickSearchInput.tsx:98:42 - error TS2722: Cannot invoke an object which is possibly 'undefined'.

98         if (inkStdin.isRawModeSupported) inkStdin.setRawMode(true);
                                            ~~~~~~~~~~~~~~~~~~~

node_modules/ink-quicksearch-input/src/QuickSearchInput.tsx:102:46 - error TS2722: Cannot invoke an object which is possibly 'undefined'.

102             if (inkStdin.isRawModeSupported) inkStdin.setRawMode(false);
                                                 ~~~~~~~~~~~~~~~~~~~


Found 2 errors.
```

This is due to declaration file mapped to source code - this causes typescript compiler to check types in the whole source file even if `skipLibCheck` is set to `true`

Updating `tsconfig` to emit actual declaration file and updating corresponding entries in `package.json`