### PR TITLE
Fix: Use option highlightComponent instead of default

### DIFF
--- a/src/QuickSearchInput.tsx
+++ b/src/QuickSearchInput.tsx
@@ -273,7 +273,7 @@ export const QuickSearch: FC<QuickSearchProps> = (props) => {
             {
                 !usingLimitedView ? null : (
                     <Box key='num-visible-items'>
-                        <HighlightComponent>Viewing {begin}-{end} of {matchingItems.length} matching items ({items.length} items overall)</HighlightComponent>
+                        <Highlight>Viewing {begin}-{end} of {matchingItems.length} matching items ({items.length} items overall)</Highlight>
                     </Box>
                 )
             }


### PR DESCRIPTION
Without this change you are unable to use this lib since the default components don't work with the latest ink version.